### PR TITLE
fix: update migrator CLI to work on Linux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -144,9 +144,9 @@
       "dev": true
     },
     "@reactioncommerce/migrator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@reactioncommerce/migrator/-/migrator-1.0.0.tgz",
-      "integrity": "sha512-G2qhA0AIdkZjDN2+FYHAxrNAAJZl2w0CmEnanWRHWMk/qWR+iL4Q+v5uS3ZHs99jndpxGUArxkssqkZ2v/k8tg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@reactioncommerce/migrator/-/migrator-1.0.1.tgz",
+      "integrity": "sha512-RG2bd/WUxWw1XF01L4DDKbxGR1v6iadU9ICQoYPxBWki5ma36Xa8ugjbpo4/5hs0/ksLqQs5yUVyqK06wMSTLg==",
       "requires": {
         "chalk": "^2.4.2",
         "cli-progress": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@reactioncommerce/migrator": "^1.0.0",
+    "@reactioncommerce/migrator": "^1.0.1",
     "@reactioncommerce/random": "^1.0.2",
     "lodash": "^4.17.15"
   },


### PR DESCRIPTION
## Changes
Pulls in an updated version of the migrator CLI that has this change: https://github.com/reactioncommerce/migrator/pull/2

## Testing
On a Linux computer, check out this PR branch, `npm install`, and then verify that a migrator command works:

```
MONGO_URL=mongodb://localhost:27017/reaction npx migrator report
```