### PR TITLE
update migrations from simple authorization package

### DIFF
--- a/migrator.config.js
+++ b/migrator.config.js
@@ -7,8 +7,8 @@ export default {
     },
     {
       namespace: "simple-authorization",
-      package: "@reactioncommerce/plugin-simple-authorization",
-      version: 4
+      package: "@reactioncommerce/api-plugin-authorization-simple",
+      version: 5
     }
   ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -266,28 +266,204 @@
         }
       }
     },
-    "@reactioncommerce/api-utils": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@reactioncommerce/api-utils/-/api-utils-1.7.3.tgz",
-      "integrity": "sha512-QweYvcX+j5ZCufphd7dQQ+dBFE9CbcWLqa+R0x9t4Q1YOgSU5LynN2Usdvm0VnUKgsRoIpqeE4T7xFcMnREgMQ==",
+    "@reactioncommerce/api-plugin-authorization-simple": {
+      "version": "1.3.0",
+      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/@reactioncommerce/api-plugin-authorization-simple/-/api-plugin-authorization-simple-1.3.0.tgz",
+      "integrity": "sha1-JVGhesfbKLyewRsjjpl3IwQvx/s=",
       "requires": {
-        "@reactioncommerce/logger": "^1.1.2",
-        "@reactioncommerce/random": "^1.0.1",
+        "@reactioncommerce/api-utils": "^1.14.2",
+        "@reactioncommerce/db-version-check": "^1.0.0",
+        "@reactioncommerce/logger": "^1.1.3",
+        "@reactioncommerce/random": "^1.0.2",
         "@reactioncommerce/reaction-error": "^1.0.1",
-        "accounting-js": "^1.1.1",
-        "callsite": "^1.0.0",
-        "graphql": "^14.5.8",
-        "graphql-fields": "^2.0.3",
-        "graphql-relay": "^0.6.0",
         "lodash": "^4.17.15",
-        "ramda": "^0.26.1",
-        "transliteration": "^2.1.7"
+        "ramda": "^0.27.0"
       },
       "dependencies": {
-        "ramda": {
-          "version": "0.26.1",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
-          "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
+        "@reactioncommerce/api-utils": {
+          "version": "1.14.5",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/@reactioncommerce/api-utils/-/api-utils-1.14.5.tgz",
+          "integrity": "sha1-FRQqrKeo47k4W0JsjGG1iIAfWGY=",
+          "requires": {
+            "@jest/globals": "^26.0.1",
+            "@reactioncommerce/logger": "^1.1.3",
+            "@reactioncommerce/random": "^1.0.2",
+            "@reactioncommerce/reaction-error": "^1.0.1",
+            "accounting-js": "^1.1.1",
+            "callsite": "^1.0.0",
+            "envalid": "^6.0.2",
+            "graphql-fields": "^2.0.3",
+            "graphql-relay": "^0.6.0",
+            "lodash": "^4.17.15",
+            "ramda": "^0.27.0",
+            "transliteration": "^2.1.9"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U="
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "envalid": {
+          "version": "6.0.2",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/envalid/-/envalid-6.0.2.tgz",
+          "integrity": "sha1-cTl3DgiazJRcDke1B11ykV2Gg+g=",
+          "requires": {
+            "chalk": "^3.0.0",
+            "dotenv": "^8.2.0",
+            "meant": "^1.0.1",
+            "validator": "^13.0.0"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY="
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM="
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "transliteration": {
+          "version": "2.1.11",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/transliteration/-/transliteration-2.1.11.tgz",
+          "integrity": "sha1-hKJ0NJUlz4u58J1fzSjAfGbuaUA=",
+          "requires": {
+            "yargs": "^15.3.1"
+          }
+        },
+        "validator": {
+          "version": "13.1.1",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/validator/-/validator-13.1.1.tgz",
+          "integrity": "sha1-+IETaEc9IXOp2GEVcrWMV4PyI78="
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha1-DYehbeAa7p2L7Cv7909nhRcw9Pg=",
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha1-vmjEl1xrKr9GkjawyHA2L6sJp7A=",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
         }
       }
     },
@@ -324,20 +500,6 @@
         "inquirer": "^6.5.0",
         "mongodb": "^3.5.2",
         "pretty-ms": "^5.1.0"
-      }
-    },
-    "@reactioncommerce/plugin-simple-authorization": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@reactioncommerce/plugin-simple-authorization/-/plugin-simple-authorization-1.1.0.tgz",
-      "integrity": "sha512-rordOaNsAi5nFRruoXpOgWxzckZ3YxnluVtl3aVAg4vbYzG3yZaLDif9kHDPVItRfDIJGpEgm9lRKKd3ivla8Q==",
-      "requires": {
-        "@reactioncommerce/api-utils": "^1.7.2",
-        "@reactioncommerce/db-version-check": "^1.0.0",
-        "@reactioncommerce/logger": "^1.1.3",
-        "@reactioncommerce/random": "^1.0.2",
-        "@reactioncommerce/reaction-error": "^1.0.1",
-        "lodash": "^4.17.15",
-        "ramda": "^0.27.0"
       }
     },
     "@reactioncommerce/random": {
@@ -1753,14 +1915,6 @@
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
     },
-    "graphql": {
-      "version": "14.6.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.6.0.tgz",
-      "integrity": "sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==",
-      "requires": {
-        "iterall": "^1.2.2"
-      }
-    },
     "graphql-fields": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/graphql-fields/-/graphql-fields-2.0.3.tgz",
@@ -2021,11 +2175,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "iterall": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
     },
     "jest-diff": {
       "version": "26.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@reactioncommerce/api-plugin-accounts": "^1.4.0",
     "@reactioncommerce/migrator": "^1.0.3",
-    "@reactioncommerce/plugin-simple-authorization": "^1.1.0"
+    "@reactioncommerce/api-plugin-authorization-simple": "^1.3.0"
   },
   "devDependencies": {
     "@reactioncommerce/eslint-config": "^2.1.0",


### PR DESCRIPTION
Update migrations to version 5 for simple authorization package. Migrations were added here: https://github.com/reactioncommerce/api-plugin-authorization-simple/pull/15