### PR TITLE
chore: bump @reactioncommerce/migrator package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -297,16 +297,16 @@
       }
     },
     "@reactioncommerce/migrator": {
-      "version": "1.1.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/@reactioncommerce/migrator/-/migrator-1.1.0.tgz",
-      "integrity": "sha1-Ie4dX7CoGVCVycsEh8VjI3Ifz7E=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@reactioncommerce/migrator/-/migrator-1.1.1.tgz",
+      "integrity": "sha512-SHFhajkrQebilGmfuvAY0RjZTJse6229s2lDwv0g1CNtjo5di5g8J96uBsIg+L9dgQlEiY+a574rthGwbkja0Q==",
       "requires": {
         "chalk": "^2.4.2",
         "cli-progress": "^3.6.0",
         "commander": "^2.20.0",
         "envalid": "^6.0.1",
         "inquirer": "^6.5.0",
-        "mongodb": "^3.5.2",
+        "mongodb": "3.6.2",
         "pretty-ms": "^5.1.0"
       }
     },
@@ -422,7 +422,7 @@
     },
     "accounting-js": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/accounting-js/-/accounting-js-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/accounting-js/-/accounting-js-1.1.1.tgz",
       "integrity": "sha1-f+Sz9wwB6+C4XALF8QfxOTuIDJ4=",
       "requires": {
         "is-string": "^1.0.4",
@@ -455,8 +455,8 @@
     },
     "ansi-escapes": {
       "version": "3.2.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s="
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
     },
     "ansi-regex": {
       "version": "5.0.0",
@@ -473,12 +473,12 @@
     },
     "ansicolors": {
       "version": "0.2.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/ansicolors/-/ansicolors-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
       "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
     },
     "ansistyles": {
       "version": "0.1.3",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/ansistyles/-/ansistyles-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
       "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk="
     },
     "argparse": {
@@ -531,7 +531,7 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "ast-types-flow": {
@@ -548,12 +548,12 @@
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
@@ -592,7 +592,7 @@
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
@@ -600,8 +600,8 @@
     },
     "bl": {
       "version": "2.2.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/bl/-/bl-2.2.1.tgz",
-      "integrity": "sha1-jBGntzBlXF1WiYzchxIk9A/ZAdU=",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -626,8 +626,8 @@
     },
     "bson": {
       "version": "1.1.5",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/bson/-/bson-1.1.5.tgz",
-      "integrity": "sha1-Kqrpj832dQwISLDLod3sPHMGCjQ="
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
+      "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
     },
     "bunyan": {
       "version": "1.8.14",
@@ -642,7 +642,7 @@
     },
     "bunyan-format": {
       "version": "0.2.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/bunyan-format/-/bunyan-format-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/bunyan-format/-/bunyan-format-0.2.1.tgz",
       "integrity": "sha1-pLOw2ABwqGUnlBcmnj8A/wL7y0c=",
       "requires": {
         "ansicolors": "~0.2.1",
@@ -652,7 +652,7 @@
     },
     "callsite": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/callsite/-/callsite-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
       "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
     },
     "callsites": {
@@ -663,7 +663,7 @@
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
@@ -688,7 +688,7 @@
     },
     "cli-cursor": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "requires": {
         "restore-cursor": "^2.0.0"
@@ -696,8 +696,8 @@
     },
     "cli-progress": {
       "version": "3.8.2",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/cli-progress/-/cli-progress-3.8.2.tgz",
-      "integrity": "sha1-q68fxtZAE1HxbwaBF6QQVUoOuMc=",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.8.2.tgz",
+      "integrity": "sha512-qRwBxLldMSfxB+YGFgNRaj5vyyHe1yMpVeDL79c+7puGujdKJHQHydgqXDcrkvQgJ5U/d3lpf6vffSoVVUftVQ==",
       "requires": {
         "colors": "^1.1.2",
         "string-width": "^4.2.0"
@@ -720,7 +720,7 @@
     },
     "clone": {
       "version": "2.1.2",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/clone/-/clone-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "color-convert": {
@@ -738,8 +738,8 @@
     },
     "colors": {
       "version": "1.4.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha1-xQSRR51MG9rtLJztMs98fcI2D3g="
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -773,7 +773,7 @@
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
@@ -797,7 +797,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -829,13 +829,13 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "denque": {
       "version": "1.4.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/denque/-/denque-1.4.1.tgz",
-      "integrity": "sha1-Z0T/dkHBSMP4ppwwflEjXB9KN88="
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
+      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
     },
     "diff-sequences": {
       "version": "26.6.2",
@@ -867,7 +867,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
         "jsbn": "~0.1.0",
@@ -1532,7 +1532,7 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
@@ -1553,7 +1553,7 @@
     },
     "figures": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/figures/-/figures-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "requires": {
         "escape-string-regexp": "^1.0.5"
@@ -1604,7 +1604,7 @@
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
@@ -1642,7 +1642,7 @@
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -1706,7 +1706,7 @@
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
@@ -1759,7 +1759,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -1821,8 +1821,8 @@
     },
     "inquirer": {
       "version": "6.5.2",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/inquirer/-/inquirer-6.5.2.tgz",
-      "integrity": "sha1-rVCUI3XQNtMn/1KMCL1fqwiZKMo=",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
       "requires": {
         "ansi-escapes": "^3.2.0",
         "chalk": "^2.4.2",
@@ -1841,13 +1841,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -1855,7 +1855,7 @@
           "dependencies": {
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -1865,16 +1865,16 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "requires": {
             "ansi-regex": "^4.1.0"
           },
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
             }
           }
         }
@@ -1972,7 +1972,7 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "isarray": {
@@ -1988,7 +1988,7 @@
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jest-diff": {
@@ -2268,7 +2268,7 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsesc": {
@@ -2279,7 +2279,7 @@
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
@@ -2295,12 +2295,12 @@
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "requires": {
         "assert-plus": "1.0.0",
@@ -2358,7 +2358,7 @@
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
     "lodash.template": {
@@ -2394,8 +2394,8 @@
     },
     "memory-pager": {
       "version": "1.5.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/memory-pager/-/memory-pager-1.5.0.tgz",
-      "integrity": "sha1-2HUWVdItOEaCdByXLyw9bfo+ZrU=",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
       "optional": true
     },
     "message-box": {
@@ -2430,8 +2430,8 @@
     },
     "mimic-fn": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI="
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -2465,9 +2465,9 @@
       "integrity": "sha1-lQ0dhWuFr18jIbgrsItnucJ/l2Y="
     },
     "mongodb": {
-      "version": "3.6.3",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/mongodb/-/mongodb-3.6.3.tgz",
-      "integrity": "sha1-7drtDMNZhHTXoV8PKlsEhISJ/QU=",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.2.tgz",
+      "integrity": "sha512-sSZOb04w3HcnrrXC82NEh/YGCmBuRgR+C1hZgmmv4L6dBz4BkRse6Y8/q/neXer9i95fKUBbFi4KgeceXmbsOA==",
       "requires": {
         "bl": "^2.2.1",
         "bson": "^1.1.4",
@@ -2485,12 +2485,12 @@
     },
     "mute-stream": {
       "version": "0.0.7",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/mute-stream/-/mute-stream-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "mv": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/mv/-/mv-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
       "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
       "optional": true,
       "requires": {
@@ -2537,7 +2537,7 @@
     },
     "ncp": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/ncp/-/ncp-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
       "optional": true
     },
@@ -2649,7 +2649,7 @@
     },
     "onetime": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/onetime/-/onetime-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "requires": {
         "mimic-fn": "^1.0.0"
@@ -2718,8 +2718,8 @@
     },
     "parse-ms": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/parse-ms/-/parse-ms-2.1.0.tgz",
-      "integrity": "sha1-NIVlp1PUOR+lJAKZVrFyy3dTCX0="
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
+      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA=="
     },
     "path-exists": {
       "version": "3.0.0",
@@ -2755,7 +2755,7 @@
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
@@ -2830,16 +2830,16 @@
     },
     "pretty-ms": {
       "version": "5.1.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/pretty-ms/-/pretty-ms-5.1.0.tgz",
-      "integrity": "sha1-uQa90eyel5mZXDcuKxw08HP5U4Q=",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-5.1.0.tgz",
+      "integrity": "sha512-4gaK1skD2gwscCfkswYQRmddUb2GJZtzDGRjHWadVHtK/DIKFufa12MvES6/xu1tVbUYeia5bmLcwJtZJQUqnw==",
       "requires": {
         "parse-ms": "^2.1.0"
       }
     },
     "process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -2907,8 +2907,8 @@
     },
     "readable-stream": {
       "version": "2.3.7",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -2921,8 +2921,8 @@
       "dependencies": {
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
@@ -2977,13 +2977,13 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require_optional": {
       "version": "1.0.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/require_optional/-/require_optional-1.0.1.tgz",
-      "integrity": "sha1-TPNaQkf2TKPfjC7yCMxJSxyo/C4=",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
       "requires": {
         "resolve-from": "^2.0.0",
         "semver": "^5.1.0"
@@ -3000,12 +3000,12 @@
     },
     "resolve-from": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/resolve-from/-/resolve-from-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
       "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
     },
     "restore-cursor": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "requires": {
         "onetime": "^2.0.0",
@@ -3055,8 +3055,8 @@
     },
     "saslprep": {
       "version": "1.0.3",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/saslprep/-/saslprep-1.0.3.tgz",
-      "integrity": "sha1-TAL5RrVs9UKX40e6EJPnrKxM8iY=",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
       "optional": true,
       "requires": {
         "sparse-bitfield": "^3.0.3"
@@ -3131,7 +3131,7 @@
     },
     "sparse-bitfield": {
       "version": "3.0.3",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
       "optional": true,
       "requires": {
@@ -3260,16 +3260,16 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
       },
       "dependencies": {
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
@@ -3413,7 +3413,7 @@
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -3421,7 +3421,7 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
@@ -3454,7 +3454,7 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
@@ -3485,7 +3485,7 @@
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -3557,7 +3557,7 @@
     },
     "xtend": {
       "version": "2.1.2",
-      "resolved": "https://artifactory.rsglab.com:443/artifactory/api/npm/npm/xtend/-/xtend-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
       "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
       "requires": {
         "object-keys": "~0.4.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@reactioncommerce/api-plugin-accounts": "^1.6.0",
     "@reactioncommerce/api-plugin-authorization-simple": "^1.3.1",
-    "@reactioncommerce/migrator": "^1.1.0",
+    "@reactioncommerce/migrator": "^1.1.1",
     "graphql": "^15.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
bumps @reactioncommerce/migrator to `v1.1.1`.

`v1.1.1` locks `mongodb` at `v3.6.2`, which is needed as `v3.6.3` is causing migrations to fail.