### PR TITLE
refactor: migration to support new createdAt and updatedAt fields for…

### DIFF
--- a/migrator.config.js
+++ b/migrator.config.js
@@ -14,6 +14,11 @@ export default {
       namespace: "tags",
       package: "@reactioncommerce/api-plugin-tags",
       version: 2
+    },
+    {
+      namespace: "email",
+      package: "@reactioncommerce/api-plugin-email",
+      version: 2
     }
   ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@reactioncommerce/api-plugin-accounts": "^1.6.0",
         "@reactioncommerce/api-plugin-authorization-simple": "^1.3.1",
+        "@reactioncommerce/api-plugin-email": "^1.1.2",
         "@reactioncommerce/api-plugin-tags": "^1.1.5",
         "@reactioncommerce/migrator": "^1.1.1",
         "graphql": "^15.3.0",
@@ -1686,6 +1687,18 @@
         "@reactioncommerce/reaction-error": "^1.0.1",
         "lodash": "^4.17.15",
         "ramda": "^0.27.0"
+      }
+    },
+    "node_modules/@reactioncommerce/api-plugin-email": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@reactioncommerce/api-plugin-email/-/api-plugin-email-1.1.2.tgz",
+      "integrity": "sha512-8aY00JuXvi47BQvNoDhndCSP+Ebj0WUFhQoo8qmkWYH12+T96p3tkeeVxd5VmjyXRXK4Xu9RrwJpDk/XMisY1Q==",
+      "dependencies": {
+        "@reactioncommerce/api-utils": "^1.16.5",
+        "@reactioncommerce/logger": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=12.14.1"
       }
     },
     "node_modules/@reactioncommerce/api-plugin-tags": {
@@ -8606,6 +8619,15 @@
         "@reactioncommerce/reaction-error": "^1.0.1",
         "lodash": "^4.17.15",
         "ramda": "^0.27.0"
+      }
+    },
+    "@reactioncommerce/api-plugin-email": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@reactioncommerce/api-plugin-email/-/api-plugin-email-1.1.2.tgz",
+      "integrity": "sha512-8aY00JuXvi47BQvNoDhndCSP+Ebj0WUFhQoo8qmkWYH12+T96p3tkeeVxd5VmjyXRXK4Xu9RrwJpDk/XMisY1Q==",
+      "requires": {
+        "@reactioncommerce/api-utils": "^1.16.5",
+        "@reactioncommerce/logger": "^1.1.3"
       }
     },
     "@reactioncommerce/api-plugin-tags": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@reactioncommerce/api-plugin-accounts": "^1.6.0",
     "@reactioncommerce/api-plugin-authorization-simple": "^1.3.1",
+    "@reactioncommerce/api-plugin-email": "^1.1.2",
     "@reactioncommerce/api-plugin-tags": "^1.1.5",
     "@reactioncommerce/migrator": "^1.1.1",
     "graphql": "^15.3.0",


### PR DESCRIPTION
Signed-off-by: Mohan Narayana <mohan.narayana@mailchimp.com>

Refer to [this guide](https://docs.google.com/document/d/1UGCbKefm4_wpaNj44MoqujuUpCYCQjBkaOh9S-ASaKc/edit?usp=sharing) for running migrations.

This migration track add a createdAt field and updatedAt field to the existing Emails collection. This will be essential for running api-plugin-email > v1.1.2  .